### PR TITLE
Fix build failure when both --with-uds and --with-ipv6 are enabled

### DIFF
--- a/conserver/main.c
+++ b/conserver/main.c
@@ -1451,7 +1451,7 @@ main(int argc, char **argv)
 	Error("gethostname(): %s", strerror(errno));
 	Bye(EX_OSERR);
     }
-#if !USE_IPV6
+#if !USE_IPV6 && !USE_UNIX_DOMAIN_SOCKETS
     ProbeInterfaces(bindAddr);
 #endif
 #if !HAVE_CLOSEFROM
@@ -1558,14 +1558,18 @@ main(int argc, char **argv)
 	Error("getaddrinfo(%s): %s", interface, gai_strerror(s));
 	Bye(EX_OSERR);
     }
-#elif USE_UNIX_DOMAIN_SOCKETS
+#endif
+#if USE_UNIX_DOMAIN_SOCKETS
     /* Don't do any redirects if we're purely local
      * (but it allows them to see where remote consoles are)
      */
+#if !USE_IPV6
     optConf->redirect = FLAGFALSE;
+#endif
     if (interface == (char *)0)
 	interface = UDSDIR;
-#else
+#endif
+#if !USE_IPV6 && !USE_UNIX_DOMAIN_SOCKETS
     /* set up the address to bind to */
     if (interface == (char *)0 ||
 	(interface[0] == '*' && interface[1] == '\000'))

--- a/console/console.c
+++ b/console/console.c
@@ -516,10 +516,12 @@ GetPort(char *pcToHost, unsigned short sPort)
     char host[NI_MAXHOST];
     char serv[NI_MAXSERV];
     struct addrinfo *ai, *rp, hints;
-#elif USE_UNIX_DOMAIN_SOCKETS
+#endif
+#if USE_UNIX_DOMAIN_SOCKETS
     struct sockaddr_un port;
     static STRING *portPath = (STRING *)0;
-#else
+#endif
+#if !USE_IPV6 && !USE_UNIX_DOMAIN_SOCKETS
     struct hostent *hp = (struct hostent *)0;
     struct sockaddr_in port;
 #endif
@@ -586,7 +588,8 @@ GetPort(char *pcToHost, unsigned short sPort)
     return (CONSFILE *)0;
   success:
     freeaddrinfo(ai);
-#elif USE_UNIX_DOMAIN_SOCKETS
+#endif
+#if USE_UNIX_DOMAIN_SOCKETS
     if (portPath == (STRING *)0)
 	portPath = AllocString();
     BuildStringPrint(portPath, "%s/%hu", config->master, sPort);


### PR DESCRIPTION
Fixes compilation errors when both Unix Domain Sockets and IPv6 are enabled.

## Problem
The codebase was designed with IPv6, UDS, and IPv4 as mutually exclusive networking modes. When both `--with-uds` and `--with-ipv6` are enabled, compilation fails due to:

1. Type mismatch: ProbeInterfaces(bindAddr) expects in_addr_t but gets struct addrinfo *
2. Missing variable declarations when #elif blocks don't execute
3. Unreachable UDS setup code

## Solution
Converted mutually exclusive #elif blocks to separate #if blocks allowing both features to coexist.

## Testing
This addresses the compilation errors reported in https://github.com/bstansell/conserver/issues/112