### PR TITLE
Add --with-debug-symbols configure option to preserve debug symbols

### DIFF
--- a/autologin/Makefile.in
+++ b/autologin/Makefile.in
@@ -9,7 +9,7 @@ sysconfdir = @sysconfdir@
 
 ### Installation programs and flags
 INSTALL = @INSTALL@
-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
+INSTALL_PROGRAM = @INSTALL_PROGRAM@@STRIP_FLAG@
 LN_S = @LN_S@
 MKDIR = @MKDIR@
 

--- a/configure.ac
+++ b/configure.ac
@@ -263,6 +263,29 @@ AC_ARG_WITH(extmsgs,
 		;;
 	esac],[AC_MSG_RESULT(no)])
 
+AC_MSG_CHECKING(whether to keep debug symbols in binaries)
+AC_ARG_WITH(debug-symbols,
+	AS_HELP_STRING([--with-debug-symbols],[Keep debug symbols in binaries (don't strip)]),
+	[case "$withval" in
+	    yes)
+		cons_with_debug_symbols="yes"
+		AC_MSG_RESULT(yes)
+		;;
+	    *)
+		cons_with_debug_symbols="no"
+		AC_MSG_RESULT(no)
+		;;
+	esac],[cons_with_debug_symbols="no"
+	AC_MSG_RESULT(no)])
+
+# Set the strip flag based on user preference
+if test "$cons_with_debug_symbols" = "yes"; then
+    STRIP_FLAG=""
+else  
+    STRIP_FLAG=" -s"
+fi
+AC_SUBST(STRIP_FLAG)
+
 use_dash_r=no
 AC_MSG_CHECKING(whether to use -R paths as well as -L)
 AC_ARG_WITH(rpath,
@@ -894,6 +917,7 @@ fi
 echo "              dmalloc (--with-dmalloc)   : $cons_with_dmalloc"
 echo "          PAM support (--with-pam)       : $cons_with_pam"
 echo "         IPv6 support (--with-ipv6)      : $cons_with_ipv6"
+echo "        debug symbols (--with-debug-symbols): $cons_with_debug_symbols"
 echo ""
 echo "=============================================================="
 ]

--- a/conserver/Makefile.in
+++ b/conserver/Makefile.in
@@ -15,7 +15,7 @@ exampledir = $(datadir)/examples/conserver
 
 ### Installation programs and flags
 INSTALL = @INSTALL@
-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
+INSTALL_PROGRAM = @INSTALL_PROGRAM@@STRIP_FLAG@
 LN_S = @LN_S@
 MKDIR = @MKDIR@
 

--- a/console/Makefile.in
+++ b/console/Makefile.in
@@ -11,7 +11,7 @@ mandir = @mandir@
 
 ### Installation programs and flags
 INSTALL = @INSTALL@
-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
+INSTALL_PROGRAM = @INSTALL_PROGRAM@@STRIP_FLAG@
 LN_S = @LN_S@
 MKDIR = @MKDIR@
 

--- a/contrib/chat/Makefile.in
+++ b/contrib/chat/Makefile.in
@@ -10,7 +10,7 @@ mandir = @mandir@
 
 ### Installation programs and flags
 INSTALL = @INSTALL@
-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
+INSTALL_PROGRAM = @INSTALL_PROGRAM@@STRIP_FLAG@
 LN_S = @LN_S@
 MKDIR = @MKDIR@
 


### PR DESCRIPTION
Add `--with-debug-symbols` configure option to preserve debug symbols in binaries

- Add AC_ARG_WITH option for --with-debug-symbols in configure.ac
- Add STRIP_FLAG variable that conditionally includes -s flag
- Update all Makefile.in files to use @STRIP_FLAG@ instead of hard-coded -s
- Add debug symbols option to feature summary display
- Maintains backward compatibility (default behavior still strips symbols)

Fixes #114 from upstream conserver project

Generated with [Claude Code](https://claude.ai/code)