### PR TITLE
Fix null pointer safety issues (High Priority)

### DIFF
--- a/autologin/autologin.c
+++ b/autologin/autologin.c
@@ -460,7 +460,7 @@ make_utmp(char *pclogin, char *pctty)
     auto struct utmp utmp;
 
 
-    if ((char *)0 == pctty) {
+    if ((char *)0 == pclogin || (char *)0 == pctty) {
 	return;
     }
 

--- a/conserver/group.c
+++ b/conserver/group.c
@@ -408,6 +408,9 @@ ConsentFindUser(CONSENTUSERS *pCU, char *id)
     struct group *g = (struct group *)0;
     struct passwd *pwd = (struct passwd *)0;
 
+    if (id == (char *)0)
+	return (CONSENTUSERS *)0;
+
     for (; pCU != (CONSENTUSERS *)0; pCU = pCU->next) {
 	if (pCU->user->name[0] == '@' && pCU->user->name[1] != '\000') {
 	    if (close == 0) {

--- a/conserver/main.c
+++ b/conserver/main.c
@@ -826,9 +826,10 @@ SummarizeDataStructures(void)
 	 pGE = pGE->pGEnext) {
 	for (pCE = pGE->pCElist; pCE != (CONSENT *)0;
 	     pCE = pCE->pCEnext, count++) {
-	    size += strlen(pCE->server) + sizeof(CONSENT);
+	    if (pCE->server != (char *)0)
+		size += strlen(pCE->server) + sizeof(CONSENT);
 	    if (pCE->host != (char *)0)
-		size += strlen(pCE->server);
+		size += strlen(pCE->host);
 	    if (pCE->device != (char *)0)
 		size += strlen(pCE->device);
 	    if (pCE->exec != (char *)0)

--- a/conserver/readcfg.c
+++ b/conserver/readcfg.c
@@ -1360,6 +1360,8 @@ ProcessUsername(CONSENT *c, char *id)
 	return;
     }
     c->username = strdup(id);
+    if (c->username == (char *)0)
+	OutOfMem();
 }
 
 void
@@ -1809,6 +1811,8 @@ ProcessPassword(CONSENT *c, char *id)
 	return;
     }
     c->password = strdup(id);
+    if (c->password == (char *)0)
+	OutOfMem();
 }
 
 void


### PR DESCRIPTION
- Add null checks for strdup() calls in ProcessUsername/ProcessPassword (readcfg.c)
- Add parameter validation in ConsentFindUser to prevent null dereference (group.c)
- Enhanced null parameter validation in make_utmp function (autologin.c)
- Fix size calculation logic error and add null check for pCE->server (main.c)

Addresses security vulnerability that could lead to crashes and denial of service. These fixes implement defensive null checking patterns throughout the codebase.

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)